### PR TITLE
Joint animation support

### DIFF
--- a/SuperBMD/Program.cs
+++ b/SuperBMD/Program.cs
@@ -154,6 +154,8 @@ namespace SuperBMDLib
             Console.WriteLine();
             Console.WriteLine("\t-b/--profile\t\t\t\tGenerate a report with information on the .BMD/.BDL (Other formats not supported)");
             Console.WriteLine();
+            Console.WriteLine("\t-a/--animation\t\t\t\tGenerate *.bck files from animation data stored in DAE, if present");
+            Console.WriteLine();
         }
     }
 }

--- a/SuperBMDLib/SuperBMDLib.csproj
+++ b/SuperBMDLib/SuperBMDLib.csproj
@@ -81,6 +81,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="source\Animation\BCK\BCK.cs" />
+    <Compile Include="source\Animation\Track.cs" />
     <Compile Include="source\Arguments.cs" />
     <Compile Include="source\BMD\DRW1.cs" />
     <Compile Include="source\BMD\EVP1.cs" />
@@ -200,6 +202,7 @@
     <Compile Include="source\Util\IO\TGA.cs" />
     <Compile Include="source\Util\J3DUtility.cs" />
     <Compile Include="source\Util\JsonUtility.cs" />
+    <Compile Include="source\Util\QuaternionExtensions.cs" />
     <Compile Include="source\Util\StreamUtility.cs" />
     <Compile Include="source\Util\VectorUtility.cs" />
     <Compile Include="source\Util\WrapModeUtility.cs" />

--- a/SuperBMDLib/source/Animation/BCK/BCK.cs
+++ b/SuperBMDLib/source/Animation/BCK/BCK.cs
@@ -1,0 +1,515 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GameFormatReader.Common;
+using SuperBMDLib.BMD;
+using SuperBMDLib.Rigging;
+using OpenTK;
+using SuperBMD.Util;
+using System.IO;
+
+namespace SuperBMDLib.Animation
+{
+    public enum LoopMode
+    {
+        Once,
+        OnceReset,
+        Loop,
+        MirroredOnce,
+        MirroredLoop
+    }
+
+    public class BCK
+    {
+        public string Name { get; private set; }
+        public LoopMode LoopMode;
+        public byte RotationFrac;
+        public short Duration;
+
+        public Track[] Tracks;
+
+        public BCK(Assimp.Animation src_anim, List<Rigging.Bone> bone_list)
+        {
+            Name = src_anim.Name;
+            LoopMode = LoopMode.Loop;
+            RotationFrac = 0;
+            Duration = (short)(src_anim.DurationInTicks * 30.0f);
+
+            Tracks = new Track[bone_list.Count];
+
+            for (int i = 0; i < bone_list.Count; i++)
+            {
+                Assimp.NodeAnimationChannel node = src_anim.NodeAnimationChannels.Find(x => x.NodeName == bone_list[i].Name);
+
+                if (node == null)
+                    Tracks[i] = Track.Identity(bone_list[i].TransformationMatrix, Duration);
+                else
+                    Tracks[i] = GenerateTrack(node, bone_list[i]);
+            }
+        }
+
+        public BCK(EndianBinaryReader reader)
+        {
+            string magic = new string(reader.ReadChars(8));
+
+            if (magic != "J3D1bck1")
+            {
+                throw new Exception("File read was not a BCK!");
+            }
+
+            int file_size = reader.ReadInt32();
+            int section_count = reader.ReadInt32();
+
+            reader.Skip(16);
+
+            ReadAnk1(reader);
+        }
+
+        private Track GenerateTrack(Assimp.NodeAnimationChannel channel, Bone bone)
+        {
+            Track track = new Track();
+
+            track.Translation = GenerateTranslationTrack(channel.PositionKeys, bone);
+            track.Rotation = GenerateRotationTrack(channel.RotationKeys, bone);
+            track.Scale = GenerateScaleTrack(channel.ScalingKeys, bone);
+
+            return track;
+        }
+
+        private Keyframe[][] GenerateTranslationTrack(List<Assimp.VectorKey> keys, Bone bone)
+        {
+            Keyframe[] x_track = new Keyframe[keys.Count];
+            Keyframe[] y_track = new Keyframe[keys.Count];
+            Keyframe[] z_track = new Keyframe[keys.Count];
+
+            for (int i = 0; i < keys.Count; i++)
+            {
+                Assimp.VectorKey current_key = keys[i];
+                Vector3 value = new Vector3(current_key.Value.X, current_key.Value.Y, current_key.Value.Z);
+
+                x_track[i].Key = value.X;
+                x_track[i].Time = (float)current_key.Time;
+
+                y_track[i].Key = value.Y;
+                y_track[i].Time = (float)current_key.Time;
+
+                z_track[i].Key = value.Z;
+                z_track[i].Time = (float)current_key.Time;
+            }
+
+            return new Keyframe[][] { x_track, y_track, z_track };
+        }
+
+        private Keyframe[][] GenerateRotationTrack(List<Assimp.QuaternionKey> keys, Bone bone)
+        {
+            Keyframe[] x_track = new Keyframe[keys.Count];
+            Keyframe[] y_track = new Keyframe[keys.Count];
+            Keyframe[] z_track = new Keyframe[keys.Count];
+
+            for (int i = 0; i < keys.Count; i++)
+            {
+                Assimp.QuaternionKey current_key = keys[i];
+                Quaternion value = new Quaternion(current_key.Value.X, current_key.Value.Y, current_key.Value.Z, current_key.Value.W);
+                Vector3 quat_as_vec = QuaternionExtensions.ToEulerAngles(value);
+
+                x_track[i].Key = quat_as_vec.X;
+                x_track[i].Time = (float)current_key.Time;
+
+                y_track[i].Key = quat_as_vec.Y;
+                y_track[i].Time = (float)current_key.Time;
+
+                z_track[i].Key = quat_as_vec.Z;
+                z_track[i].Time = (float)current_key.Time;
+            }
+
+            return new Keyframe[][] { x_track, y_track, z_track };
+        }
+
+        private Keyframe[][] GenerateScaleTrack(List<Assimp.VectorKey> keys, Bone bone)
+        {
+            Keyframe[] x_track = new Keyframe[keys.Count];
+            Keyframe[] y_track = new Keyframe[keys.Count];
+            Keyframe[] z_track = new Keyframe[keys.Count];
+
+            for (int i = 0; i < keys.Count; i++)
+            {
+                Assimp.VectorKey current_key = keys[i];
+                Vector3 value = new Vector3(current_key.Value.X, current_key.Value.Y, current_key.Value.Z);
+
+                x_track[i].Key = value.X;
+                x_track[i].Time = (float)current_key.Time;
+
+                y_track[i].Key = value.Y;
+                y_track[i].Time = (float)current_key.Time;
+
+                z_track[i].Key = value.Z;
+                z_track[i].Time = (float)current_key.Time;
+            }
+
+            return new Keyframe[][] { x_track, y_track, z_track };
+        }
+
+        private void ReadAnk1(EndianBinaryReader reader)
+        {
+            string magic = new string(reader.ReadChars(4));
+
+            if (magic != "ANK1")
+            {
+                throw new Exception("Section read was not ANK1!");
+            }
+
+            int section_length = reader.ReadInt32();
+
+            LoopMode = (LoopMode)reader.ReadByte();
+            RotationFrac = reader.ReadByte();
+            Duration = reader.ReadInt16();
+
+            ushort keyframe_count = reader.ReadUInt16();
+            ushort scale_count = reader.ReadUInt16();
+            ushort rotation_count = reader.ReadUInt16();
+            ushort translation_count = reader.ReadUInt16();
+
+            int anim_offset = reader.ReadInt32() + 32;
+            int scale_offset = reader.ReadInt32() + 32;
+            int rotation_offset = reader.ReadInt32() + 32;
+            int translation_offset = reader.ReadInt32() + 32;
+
+            float[] scale_data = ReadFloatTable(scale_offset, scale_count, reader);
+            short[] rotation_data = ReadShortTable(rotation_offset, rotation_count, reader);
+            float[] translation_data = ReadFloatTable(translation_offset, translation_count, reader);
+
+            Tracks = new Track[keyframe_count];
+            reader.BaseStream.Seek(anim_offset, System.IO.SeekOrigin.Begin);
+
+            for (int i = 0; i < keyframe_count; i++)
+            {
+                Tracks[i].Translation = new Keyframe[3][];
+                Tracks[i].Scale = new Keyframe[3][];
+                Tracks[i].Rotation = new Keyframe[3][];
+
+                // X components
+                Tracks[i].Scale[0] = ReadFloatKeyframe(reader, scale_data);
+                Tracks[i].Rotation[0] = ReadShortKeyframe(reader, rotation_data);
+                Tracks[i].Translation[0] = ReadFloatKeyframe(reader, translation_data);
+
+                // Y components
+                Tracks[i].Scale[2] = ReadFloatKeyframe(reader, scale_data);
+                Tracks[i].Rotation[2] = ReadShortKeyframe(reader, rotation_data);
+                Tracks[i].Translation[2] = ReadFloatKeyframe(reader, translation_data);
+
+                // Z components
+                Tracks[i].Scale[1] = ReadFloatKeyframe(reader, scale_data);
+                Tracks[i].Rotation[1] = ReadShortKeyframe(reader, rotation_data);
+                Tracks[i].Translation[1] = ReadFloatKeyframe(reader, translation_data);
+            }
+        }
+
+        private float[] ReadFloatTable(int offset, int count, EndianBinaryReader reader)
+        {
+            float[] floats = new float[count];
+
+            reader.BaseStream.Seek(offset, System.IO.SeekOrigin.Begin);
+
+            for (int i = 0; i < count; i++)
+            {
+                floats[i] = reader.ReadSingle();
+            }
+
+            return floats;
+        }
+
+        private short[] ReadShortTable(int offset, int count, EndianBinaryReader reader)
+        {
+            short[] shorts = new short[count];
+
+            reader.BaseStream.Seek(offset, System.IO.SeekOrigin.Begin);
+
+            for (int i = 0; i < count; i++)
+            {
+                shorts[i] = reader.ReadInt16();
+            }
+
+            return shorts;
+        }
+
+        private Keyframe[] ReadFloatKeyframe(EndianBinaryReader reader, float[] data)
+        {
+            short count = reader.ReadInt16();
+            short index = reader.ReadInt16();
+            TangentMode tangent_mode = (TangentMode)reader.ReadInt16();
+
+            Keyframe[] key_data = new Keyframe[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                if (count == 1)
+                {
+                    key_data[i].Key = data[index];
+                    continue;
+                }
+
+                int cur_index = index;
+
+                if (tangent_mode == TangentMode.Symmetric)
+                {
+                    cur_index += 3 * i;
+                }
+                else
+                {
+                    cur_index += 4 * i;
+                }
+
+                key_data[i].Time = data[cur_index];
+                key_data[i].Key = data[cur_index + 1];
+                key_data[i].InTangent = data[cur_index + 2];
+
+                if (tangent_mode == TangentMode.Symmetric)
+                {
+                    key_data[i].OutTangent = key_data[i].InTangent;
+                }
+                else
+                {
+                    key_data[i].OutTangent = data[cur_index + 3];
+                }
+            }
+
+            return key_data;
+        }
+
+        private Keyframe[] ReadShortKeyframe(EndianBinaryReader reader, short[] data)
+        {
+            ushort count = reader.ReadUInt16();
+            ushort index = reader.ReadUInt16();
+            TangentMode tangent_mode = (TangentMode)reader.ReadInt16();
+
+            Keyframe[] key_data = new Keyframe[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                if (count == 1)
+                {
+                    key_data[i].Key = RotationShortToFloat(data[index], RotationFrac);
+                    continue;
+                }
+
+                int cur_index = index;
+
+                if (tangent_mode == TangentMode.Symmetric)
+                {
+                    cur_index += 3 * i;
+                }
+                else
+                {
+                    cur_index += 4 * i;
+                }
+
+                key_data[i].Time = data[cur_index];
+                key_data[i].Key = RotationShortToFloat(data[cur_index + 1], RotationFrac);
+
+                key_data[i].InTangent = RotationShortToFloat(data[cur_index + 2], RotationFrac);
+
+                if (tangent_mode == TangentMode.Symmetric)
+                {
+                    key_data[i].OutTangent = key_data[i].InTangent;
+                }
+                else
+                {
+                    key_data[i].OutTangent = RotationShortToFloat(data[cur_index + 3], RotationFrac);
+                }
+            }
+
+            return key_data;
+        }
+
+        public static float RotationShortToFloat(short rot, short rotation_frac)
+        {
+            float rot_scale = (float)Math.Pow(2f, rotation_frac) * (180f / 32768f);
+
+            //float test = (rot << rotation_frac) * (360.0f / 65536.0F);
+            float test = rot * rot_scale;
+            return test;
+        }
+
+        public static short RotationFloatToShort(float rot, short rotation_frac)
+        {
+            float rot_scale = (float)Math.Pow(2f, rotation_frac) * (32768f / 180f);
+
+            short test = (short)(rot * rot_scale);
+            return test;
+        }
+
+        public void Write(EndianBinaryWriter writer)
+        {
+            writer.Write("J3D1bck1".ToCharArray()); // Magic
+            writer.Write((int)0); // Placeholder for filesize
+            writer.Write((int)1); // Number of sections. It's only ever 1 for ANK1
+
+            // These are placeholder for SVN that were never used.
+            writer.Write((int)-1);
+            writer.Write((int)-1);
+            writer.Write((int)-1);
+
+            // This spot, however, was used for hacking sound data into the animation.
+            // It's the offset to the start of the sound data. Unsupported for now.
+            writer.Write((int)-1);
+
+            WriteANK1(writer);
+
+            writer.BaseStream.Seek(8, System.IO.SeekOrigin.Begin);
+            writer.Write((int)writer.BaseStream.Length);
+            writer.BaseStream.Seek(0, System.IO.SeekOrigin.End);
+        }
+
+        private void WriteANK1(EndianBinaryWriter writer)
+        {
+            long start_offset = writer.BaseStream.Length;
+
+            int ScaleCount;
+            int RotCount;
+            int TransCount;
+
+            int ScaleOffset;
+            int RotOffset;
+            int TransOffset;
+
+            byte[] KeyframeData = WriteKeyframedata(out ScaleCount, out RotCount, out TransCount, out ScaleOffset, out RotOffset, out TransOffset);
+
+            writer.Write("ANK1".ToCharArray()); // Magic
+            writer.Write((int)0); // Placeholder for section size
+
+            writer.Write((byte)LoopMode);
+            writer.Write(RotationFrac);
+            writer.Write(Duration);
+
+            writer.Write((short)Tracks.Length);
+            writer.Write((short)ScaleCount);
+            writer.Write((short)RotCount);
+            writer.Write((short)TransCount);
+
+            writer.Write((int)0x40); // Keyframes offset
+            writer.Write((int)ScaleOffset); // Scale bank offset
+            writer.Write((int)RotOffset); // Rot bank offset
+            writer.Write((int)TransOffset); // Trans bank offset
+
+            Util.StreamUtility.PadStreamWithString(writer, 32);
+
+            writer.Write(KeyframeData);
+
+            Util.StreamUtility.PadStreamWithString(writer, 32);
+
+            writer.BaseStream.Seek(start_offset + 4, System.IO.SeekOrigin.Begin);
+            writer.Write((int)(writer.BaseStream.Length - start_offset));
+            writer.BaseStream.Seek(0, System.IO.SeekOrigin.End);
+        }
+
+        private byte[] WriteKeyframedata(out int ScaleCount, out int RotCount, out int TransCount, out int ScaleOffset, out int RotOffset, out int TransOffset)
+        {
+            List<float> scale_data = new List<float>() { 1.0f };
+            List<short> rot_data = new List<short>() { 0 };
+            List<float> trans_data = new List<float>() { 0.0f };
+            byte[] keyframe_data;
+
+            using (MemoryStream mem = new MemoryStream())
+            {
+                EndianBinaryWriter keyframe_writer = new EndianBinaryWriter(mem, Endian.Big);
+
+                foreach (Track t in Tracks) // Each bone
+                {
+                    WriteFloatKeyframe(keyframe_writer, t.Scale[0], scale_data);
+                    WriteShortKeyframe(keyframe_writer, t.Rotation[0], rot_data);
+                    WriteFloatKeyframe(keyframe_writer, t.Translation[0], trans_data);
+
+                    WriteFloatKeyframe(keyframe_writer, t.Scale[1], scale_data);
+                    WriteShortKeyframe(keyframe_writer, t.Rotation[1], rot_data);
+                    WriteFloatKeyframe(keyframe_writer, t.Translation[1], trans_data);
+
+                    WriteFloatKeyframe(keyframe_writer, t.Scale[2], scale_data);
+                    WriteShortKeyframe(keyframe_writer, t.Rotation[2], rot_data);
+                    WriteFloatKeyframe(keyframe_writer, t.Translation[2], trans_data);
+                }
+
+                Util.StreamUtility.PadStreamWithString(keyframe_writer, 32);
+
+                ScaleOffset = (int)(keyframe_writer.BaseStream.Position + 0x40);
+                foreach (float f in scale_data)
+                    keyframe_writer.Write(f);
+
+                Util.StreamUtility.PadStreamWithString(keyframe_writer, 32);
+
+                RotOffset = (int)(keyframe_writer.BaseStream.Position + 0x40);
+                foreach (short s in rot_data)
+                    keyframe_writer.Write(s);
+
+                Util.StreamUtility.PadStreamWithString(keyframe_writer, 32);
+
+                TransOffset = (int)(keyframe_writer.BaseStream.Position + 0x40);
+                foreach (float f in trans_data)
+                    keyframe_writer.Write(f);
+
+                keyframe_data = mem.ToArray();
+            }
+
+            ScaleCount = scale_data.Count;
+            RotCount = rot_data.Count;
+            TransCount = trans_data.Count;
+
+            return keyframe_data;
+        }
+
+        private void WriteFloatKeyframe(EndianBinaryWriter writer, Keyframe[] keys, List<float> float_data)
+        {
+            if (keys.Length == 1) // Identity keyframes are easy because they always point to the first value in the list
+            {
+                if (!float_data.Contains(keys[0].Key))
+                    float_data.Add(keys[0].Key);
+
+                writer.Write((short)1); // Number of keys
+                writer.Write((short)float_data.IndexOf(keys[0].Key)); // Index of first key
+                writer.Write((short)0); // Tangent type, either piecewise or symmetric
+
+                return;
+            }
+
+            writer.Write((short)keys.Length);
+            writer.Write((short)float_data.Count);
+            writer.Write((short)TangentMode.Symmetric);
+
+            foreach (Keyframe k in keys)
+            {
+                float_data.Add(k.Time * 30.0f);
+                float_data.Add(k.Key);
+                float_data.Add(k.InTangent);
+            }
+        }
+
+        private void WriteShortKeyframe(EndianBinaryWriter writer, Keyframe[] keys, List<short> short_data)
+        {
+            if (keys.Length == 1)
+            {
+                short rot_value = RotationFloatToShort(keys[0].Key, RotationFrac);
+
+                if (!short_data.Contains(rot_value))
+                    short_data.Add(rot_value);
+
+                writer.Write((short)1);
+                writer.Write((short)short_data.IndexOf(rot_value));
+                writer.Write((short)0);
+
+                return;
+            }
+
+            writer.Write((short)keys.Length);
+            writer.Write((short)short_data.Count);
+            writer.Write((short)TangentMode.Symmetric);
+
+            foreach (Keyframe k in keys)
+            {
+                short_data.Add((short)(k.Time * 30.0f));
+                short_data.Add(RotationFloatToShort(k.Key, RotationFrac));
+                short_data.Add(RotationFloatToShort(k.InTangent, RotationFrac));
+            }
+        }
+    }
+}

--- a/SuperBMDLib/source/Animation/Track.cs
+++ b/SuperBMDLib/source/Animation/Track.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTK;
+using SuperBMD.Util;
+
+namespace SuperBMDLib.Animation
+{
+    public enum TangentMode
+    {
+        Symmetric,
+        Piecewise
+    }
+
+    public struct Keyframe
+    {
+        public float Time;
+        public float InTangent;
+        public float OutTangent;
+        public float Key;
+    }
+
+    public struct Track
+    {
+        public Keyframe[][] Translation;
+        public Keyframe[][] Rotation;
+        public Keyframe[][] Scale;
+
+        public bool IsIdentity;
+
+        public static Track Identity(Matrix4 Transform, float MaxTime)
+        {
+            Track ident_track = new Track();
+            Quaternion XRot = Quaternion.FromAxisAngle(Vector3.UnitX, (float)(0));
+
+            ident_track.IsIdentity = true;
+            Vector3 Translation = Transform.ExtractTranslation();
+
+            ident_track.Translation = new Keyframe[][]
+            {
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Translation.X, OutTangent = 0 } },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Translation.Y, OutTangent = 0, Time = 0} },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Translation.Z, OutTangent = 0, Time = 0} },
+            };
+
+            Quaternion Rotation = Transform.ExtractRotation();
+            Vector3 Rot_Vec = QuaternionExtensions.ToEulerAngles(Rotation);
+
+            ident_track.Rotation = new Keyframe[][]
+            {
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Rot_Vec.X, OutTangent = 0, Time = 0} },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Rot_Vec.Y, OutTangent = 0, Time = 0} },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = Rot_Vec.Z, OutTangent = 0, Time = 0} },
+            };
+
+            Vector3 Scale = Transform.ExtractScale();
+
+            ident_track.Scale = new Keyframe[][]
+            {
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = 1, OutTangent = 0, Time = 0} },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = 1, OutTangent = 0, Time = 0} },
+                new Keyframe[] { new Keyframe() { InTangent = 0, Key = 1, OutTangent = 0, Time = 0} },
+            };
+
+            return ident_track;
+        }
+    }
+}

--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -25,6 +25,7 @@ namespace SuperBMDLib
         public bool readMipmaps;
         public bool dumpHierarchy;
         public string hierarchyPath;
+        public bool exportAnims;
 
         /// <summary>
         /// Initializes a new Arguments instance from the arguments passed in to SuperBMD.
@@ -49,6 +50,7 @@ namespace SuperBMDLib
             readMipmaps = true;
             dumpHierarchy = false;
             hierarchyPath = "";
+            exportAnims = false;
 
             int positional_arguments = 0;
 
@@ -125,6 +127,10 @@ namespace SuperBMDLib
 
                         hierarchyPath = args[i + 1];
                         i++;
+                        break;
+                    case "-a":
+                    case "--animation":
+                        exportAnims = true;
                         break;
                     default:
                         if (positional_arguments == 0) {

--- a/SuperBMDLib/source/Model.cs
+++ b/SuperBMDLib/source/Model.cs
@@ -293,7 +293,7 @@ namespace SuperBMDLib
 
             vertexCount = VertexData.Attributes.Positions.Count;
 
-            if (scene.AnimationCount > 0)
+            if (args.exportAnims && scene.AnimationCount > 0)
             {
                 foreach (Assimp.Animation anm in scene.Animations)
                     BCKAnims.Add(new BCK(anm, Joints.FlatSkeleton));
@@ -352,7 +352,7 @@ namespace SuperBMDLib
             {
                 for (int i = 0; i < BCKAnims.Count; i++)
                 {
-                    string bckName = BCKAnims[i].Name != "" ? Path.Combine(outDir, $"{ BCKAnims[i].Name }.bck") : Path.Combine(outDir, $"anim_{ i }.bck");
+                    string bckName = Path.Combine(outDir, $"anim_{ i }.bck");
 
                     using (FileStream strm = new FileStream(bckName, FileMode.Create, FileAccess.Write))
                     {

--- a/SuperBMDLib/source/Util/QuaternionExtensions.cs
+++ b/SuperBMDLib/source/Util/QuaternionExtensions.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTK;
+
+namespace SuperBMD.Util
+{
+    public static class QuaternionExtensions
+    {
+        /// <summary>
+        /// Convert a Quaternion to Euler Angles. Returns the angles in [-180, 180] space in degrees.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="quat"></param>
+        /// <returns></returns>
+        public static Vector3 ToEulerAngles(this Quaternion quat)
+        {
+            return new Vector3(WMath.RadiansToDegrees(PitchFromQuat(quat)), WMath.RadiansToDegrees(YawFromQuat(quat)), WMath.RadiansToDegrees(RollFromQuat(quat)));
+        }
+
+        /// <summary>
+        /// Create a Quaternion from Euler Angles. These should be in degrees in [-180, 180] space.
+        /// </summary>
+        public static Quaternion FromEulerAngles(this Quaternion quat, Vector3 eulerAngles)
+        {
+            eulerAngles.X = WMath.DegreesToRadians(eulerAngles.X);
+            eulerAngles.Y = WMath.DegreesToRadians(eulerAngles.Y);
+            eulerAngles.Z = WMath.DegreesToRadians(eulerAngles.Z);
+
+            double c1 = Math.Cos(eulerAngles.Y / 2f);
+            double s1 = Math.Sin(eulerAngles.Y / 2f);
+            double c2 = Math.Cos(eulerAngles.X / 2f);
+            double s2 = Math.Sin(eulerAngles.X / 2f);
+            double c3 = Math.Cos(eulerAngles.Z / 2f);
+            double s3 = Math.Sin(eulerAngles.Z / 2f);
+            double c1c2 = c1 * c2;
+            double s1s2 = s1 * s2;
+
+            float w = (float)(c1c2 * c3 - s1s2 * s3);
+            float x = (float)(c1c2 * s3 + s1s2 * c3);
+            float y = (float)(s1 * c2 * c3 + c1 * s2 * s3);
+            float z = (float)(c1 * s2 * c3 - s1 * c2 * s3);
+            return new Quaternion(x, y, z, w);
+        }
+
+        private static float PitchFromQuat(Quaternion q)
+        {
+            return (float)Math.Atan2(2f * (q.W * q.X + q.Y * q.Z), 1 - (2 * (Math.Pow(q.X, 2) + Math.Pow(q.Y, 2))));
+        }
+
+        private static float YawFromQuat(Quaternion q)
+        {
+            return (float)Math.Asin(2f * (q.W * q.Y - q.X * q.Z));
+        }
+
+        private static float RollFromQuat(Quaternion q)
+        {
+            return (float)Math.Atan2(2 * (q.W * q.Z + q.X * q.Y), 1 - (2 * (Math.Pow(q.Y, 2) + Math.Pow(q.Z, 2))));
+        }
+    }
+
+    public static class WMath
+    {
+        public static int Clamp(int value, int min, int max)
+        {
+            if (value < min)
+                value = min;
+            if (value > max)
+                value = max;
+
+            return value;
+        }
+
+        public static float Clamp(float value, float min, float max)
+        {
+            if (value < min)
+                value = min;
+            if (value > max)
+                value = max;
+
+            return value;
+        }
+
+        public static float Lerp(float a, float b, float t)
+        {
+            return (1 - t) * a + t * b;
+        }
+
+        public static float DegreesToRadians(float degrees)
+        {
+            return degrees * (float)(Math.PI / 180.0);
+        }
+
+        public static float RadiansToDegrees(float radians)
+        {
+            return radians * (float)(180.0 / Math.PI);
+        }
+
+        public static float RotationShortToFloat(short rotation)
+        {
+            return rotation * (180 / 32768f);
+        }
+
+        public static short RotationFloatToShort(float rotation)
+        {
+            return (short)(rotation * (32768f / 180f));
+        }
+
+        /// <summary>
+        /// Calculate the number of bytes required to pad the specified
+        /// number up to the next 16 byte alignment.
+        /// </summary>
+        /// <param name="inPos">Position in memory stream that you're currently at.</param>
+        /// <returns>The delta required to get to the next 16 byte alignment.</returns>
+        public static int Pad16Delta(long inPos)
+        {
+            // Pad up to a 16 byte alignment
+            // Formula: (x + (n-1)) & ~(n-1)
+            long nextAligned = (inPos + 0xF) & ~0xF;
+
+            long delta = nextAligned - inPos;
+            return (int)delta;
+        }
+
+        /// <summary>
+        /// Calculate the number of bytes required to pad the specified
+        /// number up to the next 32 byte alignment.
+        /// </summary>
+        /// <param name="inPos">Position in memory stream that you're currently at.</param>
+        /// <returns>The delta required to get to the next 32 byte alignment.</returns>
+        public static int Pad32Delta(long inPos)
+        {
+            // Pad up to a 32 byte alignment
+            // Formula: (x + (n-1)) & ~(n-1)
+            long nextAligned = (inPos + 0x1F) & ~0x1F;
+
+            long delta = nextAligned - inPos;
+            return (int)delta;
+        }
+
+        public static int Floor(float val)
+        {
+            return (int)Math.Floor(val);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability for users to export primitive *.bck files from animation data stored in COLLADA files. The following limitations apply and will likely not be fixed for this feature of SuperBMD:

* Neither Blender nor Assimp support tangent data in COLLADA files, so animations cannot be fine-tuned through the use of Bezier/Hermite interpolation.
* Blender's default behavior for exporting animation data to COLLADA files is to *only* export the active action, and it will not export any others; thus, exporting multiple animations would require running the tool multiple times.

While this new feature for SuperBMD should prove useful for many, extra control of the animations could be achieved through a Blender plugin that directly generates BCK files without going through COLLADA serialization. This would circumvent the limitations outlined above.