### PR TITLE
Add option to disallow exporting normal information in SHP1

### DIFF
--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -34,6 +34,7 @@ namespace SuperBMDLib
         public string skeleton_root_marker;
         public string skeleton_root_name;
         public bool skeleton_autodetect;
+        public bool include_normals;
 
         /// <summary>
         /// Initializes a new Arguments instance from the arguments passed in to SuperBMD.
@@ -67,6 +68,7 @@ namespace SuperBMDLib
             skeleton_root_marker = "skeleton_root";
             skeleton_root_name = null;
             skeleton_autodetect = false;
+            include_normals = true;
             int positional_arguments = 0;
 
             for (int i = 0; i < args.Length; i++)
@@ -177,6 +179,9 @@ namespace SuperBMDLib
                         break;
                     case "--root_autodetect":
                         skeleton_autodetect = true;
+                        break;
+                    case "--no_normals":
+                        include_normals = false;
                         break;
                     default:
                         if (positional_arguments == 0) {

--- a/SuperBMDLib/source/BMD/SHP1.cs
+++ b/SuperBMDLib/source/BMD/SHP1.cs
@@ -147,8 +147,8 @@ namespace SuperBMDLib.BMD
             reader.BaseStream.Seek(offset + shp1Size, System.IO.SeekOrigin.Begin);
         }
 
-        private SHP1(   Assimp.Scene scene, VertexData vertData, Dictionary<string, int> boneNames, EVP1 envelopes, DRW1 partialWeight, 
-            string tristripMode = "static", bool degenerateTriangles = false)
+        private SHP1(Assimp.Scene scene, VertexData vertData, Dictionary<string, int> boneNames, EVP1 envelopes, DRW1 partialWeight,
+            string tristripMode = "static", bool include_normals = false, bool degenerateTriangles = false)
         {
             Shapes = new List<Shape>();
             RemapTable = new List<int>();
@@ -179,11 +179,11 @@ namespace SuperBMDLib.BMD
 
                 if (forceUnweighted) { 
                     Console.WriteLine(String.Format("\nMesh {0} forced to be unweighted.", mesh.Name));
-                    meshShape.SetDescriptorAttributes(mesh, 1);
+                    meshShape.SetDescriptorAttributes(mesh, 1, include_normals);
                 }
                 else
                 {
-                    meshShape.SetDescriptorAttributes(mesh, boneNames.Count);
+                    meshShape.SetDescriptorAttributes(mesh, boneNames.Count, include_normals);
                 }
 
                 if (boneNames.Count > 1 && !forceUnweighted)
@@ -205,10 +205,10 @@ namespace SuperBMDLib.BMD
             return new SHP1(reader, offset, modelstats);
         }
 
-        public static SHP1 Create(  Scene scene, Dictionary<string, int> boneNames, VertexData vertData, EVP1 evp1, DRW1 drw1, 
-            string tristrip_mode = "static", bool degenerateTriangles = false)
+        public static SHP1 Create(Scene scene, Dictionary<string, int> boneNames, VertexData vertData, EVP1 evp1, DRW1 drw1,
+            string tristrip_mode = "static", bool include_normals = false, bool degenerateTriangles = false)
         {
-            SHP1 shp1 = new SHP1(scene, vertData, boneNames, evp1, drw1, tristrip_mode, degenerateTriangles);
+            SHP1 shp1 = new SHP1(scene, vertData, boneNames, evp1, drw1, tristrip_mode, include_normals, degenerateTriangles);
 
             return shp1;
         }

--- a/SuperBMDLib/source/Geometry/Shape.cs
+++ b/SuperBMDLib/source/Geometry/Shape.cs
@@ -59,7 +59,7 @@ namespace SuperBMDLib.Geometry
             MatrixType = matrixType;
         }
 
-        public void SetDescriptorAttributes(Mesh mesh, int jointCount)
+        public void SetDescriptorAttributes(Mesh mesh, int jointCount, bool include_normals)
         {
             int indexOffset = 0;
 
@@ -68,7 +68,7 @@ namespace SuperBMDLib.Geometry
 
             if (mesh.HasVertices)
                 Descriptor.SetAttribute(Enums.GXVertexAttribute.Position, Enums.VertexInputType.Index16, indexOffset++);
-            if (mesh.HasNormals)
+            if (mesh.HasNormals && include_normals)
                 Descriptor.SetAttribute(Enums.GXVertexAttribute.Normal, Enums.VertexInputType.Index16, indexOffset++);
             for (int i = 0; i < 2; i++)
             {

--- a/SuperBMDLib/source/Model.cs
+++ b/SuperBMDLib/source/Model.cs
@@ -259,7 +259,7 @@ namespace SuperBMDLib
             Console.WriteLine();
             Console.WriteLine("Generating the Mesh Data ->");
             Shapes = SHP1.Create(scene, Joints.BoneNameIndices, VertexData.Attributes, SkinningEnvelopes, PartialWeightData, 
-                args.tristrip_mode, args.degenerateTriangles);
+                args.tristrip_mode, args.include_normals, args.degenerateTriangles);
 
             //Joints.UpdateBoundingBoxes(VertexData);
 


### PR DESCRIPTION
As the normal information in the SHP1 packet of a model seems to not be useful in certain cases and simply adds extra data, let's allow the user to optionally disable normal data from the SHP1 packet.