### PR TITLE
Env mapping fixes and bone transform mode setting

### DIFF
--- a/SuperBMD/Program.cs
+++ b/SuperBMD/Program.cs
@@ -169,7 +169,7 @@ namespace SuperBMDLib
             Console.WriteLine("Made possible with help from arookas, LordNed, xDaniel, and many others.");
             Console.WriteLine("Visit https://github.com/Sage-of-Mirrors/SuperBMD/wiki for more information.");
             Console.WriteLine();
-            Console.WriteLine("Usage: SuperBMD.exe (inputfilepath) [outputfilepath] [-m/mat filepath]\n" +
+            Console.WriteLine("Usage: SuperBMD.exe (inputfilepath) [outputfilepath] [-m/--mat filepath]\n" +
                               "       [-x/--texheader filepath] [-t/--tristrip mode] [-r/--rotate] [-b/--bdl]");
             Console.WriteLine();
             Console.WriteLine("Parameters:");
@@ -182,16 +182,22 @@ namespace SuperBMDLib
             Console.WriteLine("\t\tstatic: Only generate tristrips for static (unrigged) meshes.");
             Console.WriteLine("\t\tall:    Generate tristrips for all meshes.");
             Console.WriteLine("\t\tnone:   Do not generate tristrips.");
+            Console.WriteLine("\t--transform_mode        mode\t\tTransform mode for bone animation transforms.");
+            Console.WriteLine("\t\tBasic");
+            Console.WriteLine("\t\tXsi");
+            Console.WriteLine("\t\tMaya");
+            Console.WriteLine("\t\tMask");
             Console.WriteLine();
             Console.WriteLine("\t-r/--rotate\t\t\t\tRotate the model from Z-up to Y-up orientation.");
             Console.WriteLine("\t-b/--bdl\t\t\t\tGenerate a BDL instead of a BMD.");
-            Console.WriteLine("\t-b/--nosort\t\t\t\tDisable naturalistic sorting of meshes by name.");
-            Console.WriteLine("\t-b/--onematpermesh\t\t\tEnsure one material per mesh.");
-            Console.WriteLine("\t-b/--exportobj\t\t\t\tIf input is BMD/BDL, export the model as Wavefront OBJ instead of Collada (.DAE).");
-            Console.WriteLine("\t-b/--texfloat32\t\t\t\tOn conversion into BMD, always store texture UV coordinates as 32 bit floats.");
-            Console.WriteLine("\t-b/--degeneratetri\t\t\tOn conversion into BMD, write triangle lists as triangle strips using degenerate triangles.");
+            Console.WriteLine("\t--nosort\t\t\t\tDisable naturalistic sorting of meshes by name.");
+            Console.WriteLine("\t--onematpermesh\t\t\tEnsure one material per mesh.");
+            Console.WriteLine("\t--exportobj\t\t\t\tIf input is BMD/BDL, export the model as Wavefront OBJ instead of Collada (.DAE).");
+            Console.WriteLine("\t--texfloat32\t\t\t\tOn conversion into BMD, always store texture UV coordinates as 32 bit floats.");
+            Console.WriteLine("\t--degeneratetri\t\t\tOn conversion into BMD, write triangle lists as triangle strips using degenerate triangles.");
+            Console.WriteLine("\t--envtex_attribute\t\t\tOn conversion into BMD, create a TexMtxIdx attribute for every mesh with an environment mapped texture.");
             Console.WriteLine();
-            Console.WriteLine("\t-b/--profile\t\t\t\tGenerate a report with information on the .BMD/.BDL (Other formats not supported)");
+            Console.WriteLine("\t--profile\t\t\t\tGenerate a report with information on the .BMD/.BDL (Other formats not supported)");
             Console.WriteLine();
             Console.WriteLine("\t-a/--animation\t\t\t\tGenerate *.bck files from animation data stored in DAE, if present");
             Console.WriteLine();

--- a/SuperBMDLib/SuperBMDLib.csproj
+++ b/SuperBMDLib/SuperBMDLib.csproj
@@ -177,6 +177,7 @@
     <Compile Include="source\Materials\IO\Int16ColorIO.cs" />
     <Compile Include="source\Rigging\Weight.cs" />
     <Compile Include="source\Scenegraph\Enums\NodeType.cs" />
+    <Compile Include="source\Scenegraph\Enums\TransformMode.cs" />
     <Compile Include="source\Scenegraph\SceneNode.cs" />
     <Compile Include="source\Util\BoundingVolume.cs" />
     <Compile Include="source\Util\IO\NameTableIO.cs" />

--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -39,6 +39,8 @@ namespace SuperBMDLib
         public string texture_path;
         public string output_material_folder;
         public bool file_name_as_mat_name;
+        public Scenegraph.Enums.TransformMode transform_mode;
+        public bool add_envtex_attribute;
 
         /// <summary>
         /// Initializes a new Arguments instance from the arguments passed in to SuperBMD.
@@ -77,6 +79,8 @@ namespace SuperBMDLib
             texture_path = "";
             file_name_as_mat_name = false;
             output_material_folder = "";
+            transform_mode = Scenegraph.Enums.TransformMode.Xsi;
+            add_envtex_attribute = false;
             int positional_arguments = 0;
 
             for (int i = 0; i < args.Length; i++)
@@ -214,6 +218,14 @@ namespace SuperBMDLib
                         break;
                     case "--no_normals":
                         include_normals = false;
+                        break;
+                    case "--transform_mode":
+                        if (i + 1 >= args.Length)
+                            throw new Exception("The parameters were malformed.");
+                        transform_mode = (Scenegraph.Enums.TransformMode)Enum.Parse(typeof(Scenegraph.Enums.TransformMode), args[i + 1]);
+                        break;
+                    case "--add_envtex_attribute":
+                        add_envtex_attribute = true;
                         break;
                     default:
                         if (positional_arguments == 0) {

--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -223,6 +223,7 @@ namespace SuperBMDLib
                         if (i + 1 >= args.Length)
                             throw new Exception("The parameters were malformed.");
                         transform_mode = (Scenegraph.Enums.TransformMode)Enum.Parse(typeof(Scenegraph.Enums.TransformMode), args[i + 1]);
+                        i++;
                         break;
                     case "--add_envtex_attribute":
                         add_envtex_attribute = true;

--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -225,7 +225,7 @@ namespace SuperBMDLib
                         transform_mode = (Scenegraph.Enums.TransformMode)Enum.Parse(typeof(Scenegraph.Enums.TransformMode), args[i + 1]);
                         i++;
                         break;
-                    case "--add_envtex_attribute":
+                    case "--envtex_attribute":
                         add_envtex_attribute = true;
                         break;
                     default:

--- a/SuperBMDLib/source/BMD/INF1.cs
+++ b/SuperBMDLib/source/BMD/INF1.cs
@@ -20,6 +20,8 @@ namespace SuperBMDLib.BMD
         public List<SceneNode> FlatNodes { get; set; }
         public SceneNode Root { get; set; }
 
+        private TransformMode transformMode;
+
         public INF1() {
             FlatNodes = new List<SceneNode>();
             Root = null;
@@ -70,11 +72,12 @@ namespace SuperBMDLib.BMD
             reader.BaseStream.Seek(offset + inf1Size, System.IO.SeekOrigin.Begin);
         }
 
-        public INF1(Scene scene, JNT1 skeleton, bool mat_strict)
+        public INF1(Scene scene, JNT1 skeleton, bool mat_strict, TransformMode mode)
         {
             FlatNodes = new List<SceneNode>();
             Root = new SceneNode(NodeType.Joint, 0, null);
             FlatNodes.Add(Root);
+            transformMode = mode;
 
             int downNodeCount = 0;
 
@@ -299,7 +302,7 @@ namespace SuperBMDLib.BMD
 
             writer.Write("INF1".ToCharArray());
             writer.Write(0); // Placeholder for section size
-            writer.Write((short)1);
+            writer.Write((short)transformMode);
             writer.Write((short)-1);
 
             writer.Write(packetCount); // Number of packets

--- a/SuperBMDLib/source/BMD/MAT3.cs
+++ b/SuperBMDLib/source/BMD/MAT3.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json.Converters;
 
 namespace SuperBMDLib.BMD
 {
-    struct PresetResult {
+    public struct PresetResult {
         public PresetResult(Material mat, int i, string newname)
         {
             preset = mat;
@@ -65,7 +65,7 @@ namespace SuperBMDLib.BMD
         private List<byte> NumTexGensBlock;
         private List<byte> NumTevStagesBlock;
 
-        private string[] delimiter = new string[] {":" };
+        private static string[] delimiter = new string[] {":" };
 
         public MAT3(EndianBinaryReader reader, int offset, BMDInfo modelstats=null)
         {
@@ -568,7 +568,7 @@ namespace SuperBMDLib.BMD
             return mat_presets.IndexOf(mat);
         }
 
-        private PresetResult? FindMatPreset(string name, List<Material> mat_presets, bool mat_strict) {
+        public static PresetResult? FindMatPreset(string name, List<Material> mat_presets, bool mat_strict) {
             if (mat_presets == null) {
                 return null;
             } 

--- a/SuperBMDLib/source/BMD/SHP1.cs
+++ b/SuperBMDLib/source/BMD/SHP1.cs
@@ -164,15 +164,15 @@ namespace SuperBMDLib.BMD
                 }*/
                 if (mesh.Name.Contains("BillXY")) {
                     meshShape = new Shape(MatrixType.BillboardXY); // Matrix Type 1, XY Billboard
-                    Console.Write("Billboarding on the X & Y axis");
+                    Console.WriteLine("Billboarding on the X & Y axis");
                 }
                 else if (mesh.Name.Contains("BillX")) {
                     meshShape = new Shape(MatrixType.BillboardX); // Matrix Type 2, X Billboard, i.e. the X axis is always turned towards camera
-                    Console.Write("Billboarding on the X axis");
+                    Console.WriteLine("Billboarding on the X axis");
                 }
                 else {
-                     meshShape = new Shape(); // Matrix Type 3, normal
-                    Console.Write("Normal Mesh");
+                    meshShape = new Shape(); // Matrix Type 3, normal
+                    Console.WriteLine("Normal Mesh");
                 }
 
                 // Force a mesh in an otherwise rigged model to be "unrigged"

--- a/SuperBMDLib/source/BMD/SHP1.cs
+++ b/SuperBMDLib/source/BMD/SHP1.cs
@@ -148,7 +148,7 @@ namespace SuperBMDLib.BMD
         }
 
         private SHP1(Assimp.Scene scene, VertexData vertData, Dictionary<string, int> boneNames, EVP1 envelopes, DRW1 partialWeight,
-            string tristripMode = "static", bool include_normals = false, bool degenerateTriangles = false)
+            string tristripMode = "static", bool include_normals = false, bool degenerateTriangles = false, bool addEnvAttrib = false, List<Materials.Material> mat_presets = null)
         {
             Shapes = new List<Shape>();
             RemapTable = new List<int>();
@@ -157,6 +157,7 @@ namespace SuperBMDLib.BMD
             {
                 Console.Write(mesh.Name+": ");
                 Shape meshShape;
+                string matName = scene.Materials[mesh.MaterialIndex].Name;
 
                 /*if (mesh.Name.Contains("Bill0")) {
                     meshShape = new Shape(0); // Matrix Type 0, unknown
@@ -179,11 +180,11 @@ namespace SuperBMDLib.BMD
 
                 if (forceUnweighted) { 
                     Console.WriteLine(String.Format("\nMesh {0} forced to be unweighted.", mesh.Name));
-                    meshShape.SetDescriptorAttributes(mesh, 1, include_normals);
+                    meshShape.SetDescriptorAttributes(mesh, 1, include_normals, addEnvAttrib, matName, mat_presets);
                 }
                 else
                 {
-                    meshShape.SetDescriptorAttributes(mesh, boneNames.Count, include_normals);
+                    meshShape.SetDescriptorAttributes(mesh, boneNames.Count, include_normals, addEnvAttrib, matName, mat_presets);
                 }
 
                 if (boneNames.Count > 1 && !forceUnweighted)
@@ -229,9 +230,9 @@ namespace SuperBMDLib.BMD
         }
 
         public static SHP1 Create(Scene scene, Dictionary<string, int> boneNames, VertexData vertData, EVP1 evp1, DRW1 drw1,
-            string tristrip_mode = "static", bool include_normals = false, bool degenerateTriangles = false)
+            string tristrip_mode = "static", bool include_normals = false, bool degenerateTriangles = false, bool addEnvAttrib = false, List<Materials.Material> mat_presets = null)
         {
-            SHP1 shp1 = new SHP1(scene, vertData, boneNames, evp1, drw1, tristrip_mode, include_normals, degenerateTriangles);
+            SHP1 shp1 = new SHP1(scene, vertData, boneNames, evp1, drw1, tristrip_mode, include_normals, degenerateTriangles, addEnvAttrib, mat_presets);
 
             return shp1;
         }

--- a/SuperBMDLib/source/Geometry/Shape.cs
+++ b/SuperBMDLib/source/Geometry/Shape.cs
@@ -547,6 +547,44 @@ namespace SuperBMDLib.Geometry
 
                                     vert.SetAttributeIndex(Enums.GXVertexAttribute.PositionMatrixIdx, (uint)pack.MatrixIndices.IndexOf(newMatrixIndex));
                                     break;
+                                case Enums.GXVertexAttribute.Tex0Mtx:
+                                case Enums.GXVertexAttribute.Tex1Mtx:
+                                case Enums.GXVertexAttribute.Tex2Mtx:
+                                case Enums.GXVertexAttribute.Tex3Mtx:
+                                case Enums.GXVertexAttribute.Tex4Mtx:
+                                case Enums.GXVertexAttribute.Tex5Mtx:
+                                case Enums.GXVertexAttribute.Tex6Mtx:
+                                case Enums.GXVertexAttribute.Tex7Mtx:
+                                    int texMtxNum = (int)attrib - 1;
+
+                                    int matrixIndex = -1;
+
+                                    if (curWeight.WeightCount == 1)
+                                    {
+                                        matrixIndex = partialWeight.MeshWeights.IndexOf(curWeight);
+                                    }
+                                    else
+                                    {
+                                        if (!envelopes.Weights.Contains(curWeight))
+                                            envelopes.Weights.Add(curWeight);
+
+                                        int envIndex = envelopes.Weights.IndexOf(curWeight);
+                                        int drwIndex = partialWeight.MeshWeights.IndexOf(curWeight);
+
+                                        if (drwIndex == -1)
+                                        {
+                                            throw new System.Exception($"Model has unweighted vertices in mesh \"{mesh.Name}\". Please weight all vertices to at least one bone.");
+                                        }
+
+                                        matrixIndex = drwIndex;
+                                        partialWeight.Indices[drwIndex] = envIndex;
+                                    }
+
+                                    if (!pack.MatrixIndices.Contains(matrixIndex))
+                                        pack.MatrixIndices.Add(matrixIndex);
+
+                                    vert.SetAttributeIndex(Enums.GXVertexAttribute.Tex0Mtx + texMtxNum, (uint)pack.MatrixIndices.IndexOf(matrixIndex));
+                                    break;
                                 case Enums.GXVertexAttribute.Position:
                                     List<Vector3> posData = (List<Vector3>)vertData.GetAttributeData(Enums.GXVertexAttribute.Position);
                                     Vector3 vertPos = mesh.Vertices[vertIndex].ToOpenTKVector3();
@@ -560,7 +598,8 @@ namespace SuperBMDLib.Geometry
                                         AttributeData.Positions.Add(transVec);
                                         vert.SetAttributeIndex(Enums.GXVertexAttribute.Position, (uint)posData.IndexOf(transVec));
                                     }
-                                    else {
+                                    else 
+                                    {
                                         if (!posData.Contains(vertPos))
                                             posData.Add(vertPos);
                                         AttributeData.Positions.Add(vertPos);
@@ -578,7 +617,8 @@ namespace SuperBMDLib.Geometry
                                         vertNrm = Vector3.TransformNormal(vertNrm, ibm);
                                         if (!normData.Contains(vertNrm))
                                             normData.Add(vertNrm);
-                                    } else
+                                    } 
+                                    else
                                     {
                                         if (!normData.Contains(vertNrm))
                                             normData.Add(vertNrm);
@@ -740,6 +780,44 @@ namespace SuperBMDLib.Geometry
                                             pack.MatrixIndices.Add(newMatrixIndex);
 
                                         vert.SetAttributeIndex(Enums.GXVertexAttribute.PositionMatrixIdx, (uint)pack.MatrixIndices.IndexOf(newMatrixIndex));
+                                        break;
+                                    case Enums.GXVertexAttribute.Tex0Mtx:
+                                    case Enums.GXVertexAttribute.Tex1Mtx:
+                                    case Enums.GXVertexAttribute.Tex2Mtx:
+                                    case Enums.GXVertexAttribute.Tex3Mtx:
+                                    case Enums.GXVertexAttribute.Tex4Mtx:
+                                    case Enums.GXVertexAttribute.Tex5Mtx:
+                                    case Enums.GXVertexAttribute.Tex6Mtx:
+                                    case Enums.GXVertexAttribute.Tex7Mtx:
+                                        int texMtxNum = (int)attrib - 1;
+
+                                        int matrixIndex = -1;
+
+                                        if (curWeight.WeightCount == 1)
+                                        {
+                                            matrixIndex = partialWeight.MeshWeights.IndexOf(curWeight);
+                                        }
+                                        else
+                                        {
+                                            if (!envelopes.Weights.Contains(curWeight))
+                                                envelopes.Weights.Add(curWeight);
+
+                                            int envIndex = envelopes.Weights.IndexOf(curWeight);
+                                            int drwIndex = partialWeight.MeshWeights.IndexOf(curWeight);
+
+                                            if (drwIndex == -1)
+                                            {
+                                                throw new System.Exception($"Model has unweighted vertices in mesh \"{mesh.Name}\". Please weight all vertices to at least one bone.");
+                                            }
+
+                                            matrixIndex = drwIndex;
+                                            partialWeight.Indices[drwIndex] = envIndex;
+                                        }
+
+                                        if (!pack.MatrixIndices.Contains(matrixIndex))
+                                            pack.MatrixIndices.Add(matrixIndex);
+
+                                        vert.SetAttributeIndex(Enums.GXVertexAttribute.Tex0Mtx + texMtxNum, (uint)pack.MatrixIndices.IndexOf(matrixIndex));
                                         break;
                                     case Enums.GXVertexAttribute.Position:
                                         List<Vector3> posData = (List<Vector3>)vertData.GetAttributeData(Enums.GXVertexAttribute.Position);

--- a/SuperBMDLib/source/Geometry/Shape.cs
+++ b/SuperBMDLib/source/Geometry/Shape.cs
@@ -64,12 +64,11 @@ namespace SuperBMDLib.Geometry
         {
             int indexOffset = 0;
 
-            if (jointCount > 1)
-            {
+            if (jointCount > 1) {
                 Descriptor.SetAttribute(Enums.GXVertexAttribute.PositionMatrixIdx, Enums.VertexInputType.Direct, indexOffset++);
 
                 if (addEnvAttrib)
-                    SetEnvTexMtxIdxAttribute(indexOffset++, matName, mat_presets);
+                    SetEnvTexMtxIdxAttribute(ref indexOffset, matName, mat_presets);
             }
 
             if (mesh.HasVertices)
@@ -90,11 +89,12 @@ namespace SuperBMDLib.Geometry
             Console.Write(".");
         }
 
-        private void SetEnvTexMtxIdxAttribute(int index, string matName, List<Materials.Material> mat_presets = null)
+        private void SetEnvTexMtxIdxAttribute(ref int index, string matName, List<Materials.Material> mat_presets = null)
         {
             PresetResult? result = MAT3.FindMatPreset(matName, mat_presets, false);
             if (result == null)
                 return;
+
 
             Materials.Material mat = ((PresetResult)result).preset;
             for (int i = 0; i < mat.TexCoord1Gens.Length; i++)
@@ -105,7 +105,7 @@ namespace SuperBMDLib.Geometry
 
                 if (texGen.Source == Materials.Enums.TexGenSrc.Normal)
                 {
-                    Descriptor.SetAttribute(Enums.GXVertexAttribute.Tex0Mtx + i, Enums.VertexInputType.Direct, index);
+                    Descriptor.SetAttribute(Enums.GXVertexAttribute.Tex0Mtx + i, Enums.VertexInputType.Direct, index++);
                 }
             }
         }
@@ -131,11 +131,11 @@ namespace SuperBMDLib.Geometry
             return triindices;
         }
 
-        public void ProcessVerticesWithoutWeights(Mesh mesh, VertexData vertData, EVP1 envelopes, bool degenerateTriangles = false, int jointindex=0, int mtxindex=0, bool transformverts=false)
+        public void ProcessVerticesWithoutWeights(Mesh mesh, VertexData vertData, EVP1 envelopes, bool degenerateTriangles = false, int jointindex = 0, int mtxindex = 0, bool transformverts = false)
         {
             Packet pack = new Packet();
 
-            
+
             List<Enums.GXVertexAttribute> activeAttribs = Descriptor.GetActiveAttributes();
             AttributeData.SetAttributesFromList(activeAttribs);
 
@@ -145,37 +145,44 @@ namespace SuperBMDLib.Geometry
             TriStripper stripper = new TriStripper(triindices);
             List<PrimitiveBrawl> primlist = stripper.Strip();
 
-            if (degenerateTriangles) {
+            if (degenerateTriangles)
+            {
                 Console.WriteLine("Converting Triangle Lists into Triangle Strips with degenerate triangles.");
 
-                for (int i = 0; i < primlist.Count; i++) {
+                for (int i = 0; i < primlist.Count; i++)
+                {
                     PrimitiveBrawl primbrawl = primlist[i];
-                
+
                     Enums.GXPrimitiveType primtype = (Enums.GXPrimitiveType)primbrawl.Type;
 
-                    if (primtype == Enums.GXPrimitiveType.Triangles) {
+                    if (primtype == Enums.GXPrimitiveType.Triangles)
+                    {
                         PrimitiveBrawl newprim = new PrimitiveBrawl(PrimType.TriangleStrip);
                         uint lastVert = 0;
-                        for (int j = 0; j < primbrawl.Indices.Count/3; j++) {
-                            if (j > 0) {
+                        for (int j = 0; j < primbrawl.Indices.Count / 3; j++)
+                        {
+                            if (j > 0)
+                            {
                                 newprim.Indices.Add(lastVert);
-                                newprim.Indices.Add(primbrawl.Indices[(j)*3+0]);
+                                newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 0]);
                             }
-                        
-                            newprim.Indices.Add(primbrawl.Indices[(j)*3+0]);
 
-                            if ( j % 2 == 0) {
-                                newprim.Indices.Add(primbrawl.Indices[(j)*3+1]);
-                                newprim.Indices.Add(primbrawl.Indices[(j)*3+2]);
+                            newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 0]);
 
-                                lastVert = primbrawl.Indices[(j)*3+2];
+                            if (j % 2 == 0)
+                            {
+                                newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 1]);
+                                newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 2]);
+
+                                lastVert = primbrawl.Indices[(j) * 3 + 2];
                             }
-                            else {
-                                newprim.Indices.Add(primbrawl.Indices[(j)*3+2]);
-                                newprim.Indices.Add(primbrawl.Indices[(j)*3+1]);
-                            
+                            else
+                            {
+                                newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 2]);
+                                newprim.Indices.Add(primbrawl.Indices[(j) * 3 + 1]);
 
-                                lastVert = primbrawl.Indices[(j)*3+1];
+
+                                lastVert = primbrawl.Indices[(j) * 3 + 1];
                             }
                         }
                         primlist[i] = newprim;
@@ -200,12 +207,15 @@ namespace SuperBMDLib.Geometry
                     vert.SetWeight(rootWeight);
                     //int vertIndex = face.Indices[i];
 
-                    foreach (Enums.GXVertexAttribute attrib in activeAttribs) {
-                        switch (attrib) {
+                    foreach (Enums.GXVertexAttribute attrib in activeAttribs)
+                    {
+                        switch (attrib)
+                        {
                             case Enums.GXVertexAttribute.Position:
                                 List<Vector3> posData = (List<Vector3>)vertData.GetAttributeData(Enums.GXVertexAttribute.Position);
                                 Vector3 vertPos = mesh.Vertices[vertIndex].ToOpenTKVector3();
-                                if (transformverts) { 
+                                if (transformverts)
+                                {
                                     Matrix4 ibm = envelopes.InverseBindMatrices[jointindex];
 
                                     vertPos = Vector3.TransformPosition(vertPos, ibm);
@@ -239,12 +249,12 @@ namespace SuperBMDLib.Geometry
                                 List<Color> colData = (List<Color>)vertData.GetAttributeData(Enums.GXVertexAttribute.Color0 + colNo);
                                 Color vertCol = mesh.VertexColorChannels[colNo][vertIndex].ToSuperBMDColorRGBA();
 
-                                
+
                                 if (colNo == 0)
                                     AttributeData.Color_0.Add(vertCol);
                                 else
                                     AttributeData.Color_1.Add(vertCol);
-                                
+
 
                                 vert.SetAttributeIndex(Enums.GXVertexAttribute.Color0 + colNo, (uint)colData.IndexOf(vertCol));
                                 break;
@@ -261,8 +271,9 @@ namespace SuperBMDLib.Geometry
                                 Vector2 vertTexCoord = mesh.TextureCoordinateChannels[texNo][vertIndex].ToOpenTKVector2();
                                 vertTexCoord = new Vector2(vertTexCoord.X, 1.0f - vertTexCoord.Y);
 
- 
-                                switch (texNo) {
+
+                                switch (texNo)
+                                {
                                     case 0:
                                         AttributeData.TexCoord_0.Add(vertTexCoord);
                                         break;
@@ -301,7 +312,7 @@ namespace SuperBMDLib.Geometry
                 pack.Primitives.Add(prim);
             }
 
-            
+
             pack.MatrixIndices.Add(mtxindex);
             Packets.Add(pack);
 

--- a/SuperBMDLib/source/Geometry/ShapeVertexDescriptor.cs
+++ b/SuperBMDLib/source/Geometry/ShapeVertexDescriptor.cs
@@ -24,7 +24,6 @@ namespace SuperBMDLib.Geometry
 
             int index = 0;
             GXVertexAttribute attrib = (GXVertexAttribute)reader.ReadInt32();
-
             while (attrib != GXVertexAttribute.Null)
             {
                 Attributes.Add(attrib, new Tuple<VertexInputType, int>((VertexInputType)reader.ReadInt32(), index));
@@ -44,6 +43,7 @@ namespace SuperBMDLib.Geometry
             if (CheckAttribute(attribute))
                 throw new Exception($"Attribute \"{ attribute }\" is already in the vertex descriptor!");
 
+            Console.WriteLine("Adding Descriptor Attribute " + attribute);
             Attributes.Add(attribute, new Tuple<VertexInputType, int>(inputType, vertexIndex));
         }
 
@@ -75,6 +75,54 @@ namespace SuperBMDLib.Geometry
             {
                 writer.Write((int)GXVertexAttribute.PositionMatrixIdx);
                 writer.Write((int)Attributes[GXVertexAttribute.PositionMatrixIdx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex0Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex0Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex0Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex1Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex1Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex1Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex2Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex2Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex2Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex3Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex3Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex3Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex4Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex4Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex4Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex5Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex5Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex5Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex6Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex6Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex6Mtx].Item1);
+            }
+
+            if (CheckAttribute(GXVertexAttribute.Tex7Mtx))
+            {
+                writer.Write((int)GXVertexAttribute.Tex7Mtx);
+                writer.Write((int)Attributes[GXVertexAttribute.Tex7Mtx].Item1);
             }
 
             if (CheckAttribute(GXVertexAttribute.Position))

--- a/SuperBMDLib/source/Geometry/Vertex.cs
+++ b/SuperBMDLib/source/Geometry/Vertex.cs
@@ -239,42 +239,42 @@ namespace SuperBMDLib.Geometry
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex0Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex0Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex0MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex0Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex1Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex1Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex1MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex1Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex2Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex2Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex2MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex2Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex3Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex3Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex3MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex3Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex4Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex4Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex4MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex4Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex5Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex5Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex5MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex5Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex6Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex6Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex6MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex6Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Tex7Mtx))
             {
-                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex7Mtx].Item1);
+                WriteAttributeIndex(writer, 30 + Tex7MtxIndex * 3, desc.Attributes[GXVertexAttribute.Tex7Mtx].Item1);
             }
 
             if (desc.CheckAttribute(GXVertexAttribute.Position))

--- a/SuperBMDLib/source/Geometry/Vertex.cs
+++ b/SuperBMDLib/source/Geometry/Vertex.cs
@@ -237,6 +237,46 @@ namespace SuperBMDLib.Geometry
                 WriteAttributeIndex(writer, PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.PositionMatrixIdx].Item1);
             }
 
+            if (desc.CheckAttribute(GXVertexAttribute.Tex0Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex0Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex1Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex1Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex2Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex2Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex3Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex3Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex4Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex4Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex5Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex5Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex6Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex6Mtx].Item1);
+            }
+
+            if (desc.CheckAttribute(GXVertexAttribute.Tex7Mtx))
+            {
+                WriteAttributeIndex(writer, 30 + PositionMatrixIDxIndex * 3, desc.Attributes[GXVertexAttribute.Tex7Mtx].Item1);
+            }
+
             if (desc.CheckAttribute(GXVertexAttribute.Position))
             {
                 WriteAttributeIndex(writer, PositionIndex, desc.Attributes[GXVertexAttribute.Position].Item1);

--- a/SuperBMDLib/source/Model.cs
+++ b/SuperBMDLib/source/Model.cs
@@ -10,6 +10,8 @@ using SuperBMDLib.BMD;
 using SuperBMDLib.Animation;
 using System.Text.RegularExpressions;
 using System.Xml;
+using SuperBMDLib.Geometry;
+using SuperBMDLib.Geometry.Enums;
 
 namespace SuperBMDLib
 {
@@ -1109,6 +1111,7 @@ namespace SuperBMDLib
         }
         public void DisplayModelInfo(Model mod) {
             DisplayVertexAttributeInfo(mod.VertexData);
+            DisplayShapeDescriptorInfo(mod.Shapes);
             Console.WriteLine("INF: {0} scene nodes", mod.Scenegraph.FlatNodes.Count);
             Console.WriteLine("EVP1: {0} weights", mod.SkinningEnvelopes.Weights.Count);
             Console.WriteLine("EVP1: {0} inverse bind matrices", mod.SkinningEnvelopes.InverseBindMatrices.Count);
@@ -1178,6 +1181,20 @@ namespace SuperBMDLib
                 DisplayAttributeFormat(vertexData, Geometry.Enums.GXVertexAttribute.Tex7);
             }
         }
+
+        private void DisplayShapeDescriptorInfo(SHP1 shapeData)
+        {
+            int i = 0;
+            foreach (Shape shape in shapeData.Shapes)
+            {
+                Console.WriteLine($"Shape {i} has descriptor attributes:");
+                foreach (GXVertexAttribute attrib in shape.Descriptor.Attributes.Keys)
+                {
+                    Console.WriteLine($"\t{attrib}");
+                }
+            }
+        }
+
         private void DisplayAttributeFormat(VTX1 vertexData, Geometry.Enums.GXVertexAttribute attr) {
             if (vertexData.StorageFormats.ContainsKey(attr)) {
                 Tuple<Geometry.Enums.GXDataType, byte> tuple;

--- a/SuperBMDLib/source/Model.cs
+++ b/SuperBMDLib/source/Model.cs
@@ -1192,6 +1192,7 @@ namespace SuperBMDLib
                 {
                     Console.WriteLine($"\t{attrib}");
                 }
+                i++;
             }
         }
 

--- a/SuperBMDLib/source/Model.cs
+++ b/SuperBMDLib/source/Model.cs
@@ -274,7 +274,7 @@ namespace SuperBMDLib
             Console.WriteLine();
             Console.WriteLine("Generating the Mesh Data ->");
             Shapes = SHP1.Create(scene, Joints.BoneNameIndices, VertexData.Attributes, SkinningEnvelopes, PartialWeightData, 
-                args.tristrip_mode, args.include_normals, args.degenerateTriangles);
+                args.tristrip_mode, args.include_normals, args.degenerateTriangles, args.add_envtex_attribute, mat_presets);
 
             //Joints.UpdateBoundingBoxes(VertexData);
 
@@ -305,7 +305,7 @@ namespace SuperBMDLib
 
             Console.WriteLine();
             Console.Write("Generating the Joints");
-            Scenegraph = new INF1(scene, Joints, args.material_order_strict);
+            Scenegraph = new INF1(scene, Joints, args.material_order_strict, args.transform_mode);
 
             foreach (Geometry.Shape shape in Shapes.Shapes)
                 packetCount += shape.Packets.Count;

--- a/SuperBMDLib/source/Scenegraph/Enums/TransformMode.cs
+++ b/SuperBMDLib/source/Scenegraph/Enums/TransformMode.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SuperBMDLib.Scenegraph.Enums
+{
+    public enum TransformMode
+    {
+        Basic = 0x0,
+        Xsi = 0x1,
+        Maya = 0x2,
+        Mask = 0xF
+    }
+}


### PR DESCRIPTION
Additional command line options that apply the following fixes or changes:
- Env mapping is fixed by including a TexMtxIdx attribute for meshes using normals as a TexCoord1Gen source in the material.
- Specify the scenegraph bone animation transform mode.
[Source](https://github.com/pish-pish/SuperBMD/releases/tag/v2.4.6)